### PR TITLE
Tweak I2C timings to give greater setup time

### DIFF
--- a/sdk/include/platform/sunburst/platform-i2c.hh
+++ b/sdk/include/platform/sunburst/platform-i2c.hh
@@ -11,8 +11,8 @@ static const uint16_t SpcThigh[]  = {4000u, 600u, 260u};
 static const uint16_t SpcTlow[]   = {4700u, 1300u, 150u};
 static const uint16_t SpcThdSta[] = {4000u, 600u, 260u};
 static const uint16_t SpcTsuSta[] = {4700u, 600u, 260u};
-static const uint16_t SpcThdDat[] = {5000u, 1u, 1u};
-static const uint16_t SpcTsuDat[] = {250u, 100u, 50u};
+static const uint16_t SpcThdDat[] = {4000u, 1u, 1u};
+static const uint16_t SpcTsuDat[] = {500u, 100u, 50u};
 static const uint16_t SpcTBuf[]   = {4700u, 1300u, 500u};
 static const uint16_t SpcTsuSto[] = {4000u, 600u, 260u};
 


### PR DESCRIPTION
The SDA to SCL setup time was observed to be rather small (~40ns), this change increases it. In particular this allows the APDS9960 sensor to work with the Sonata I2C.

Change determined by experimentation, no particular reasoning behind the number choice.