### PR TITLE
Fix receive_watermark and make driver tolerant of FIFO size changes

### DIFF
--- a/sdk/include/platform/sunburst/platform-uart.hh
+++ b/sdk/include/platform/sunburst/platform-uart.hh
@@ -128,6 +128,23 @@ struct OpenTitanUart
 		ControlTransmitEnable = 1 << 0,
 	};
 
+	/// Status Register Fields
+	enum : uint32_t
+	{
+		/// Receive FIFO is empty.
+		StatusReceiveEmpty = 1 << 5,
+		/// Receive logic is idle.
+		StatusReceiveIdle = 1 << 4,
+		/// Transmit FIFO is empty and all bits have been transmitted.
+		StatusTransmitIdle = 1 << 3,
+		/// Transmit FIFO is empty; transmission may still be occurring.
+		StatusTransmitEmpty = 1 << 2,
+		/// Receive FIFO is full.
+		StatusReceiveFull = 1 << 1,
+		/// Transmit FIFO is full.
+		StatusTransmitFull = 1 << 0,
+	};
+
 	/// The encoding for different transmit watermark levels.
 	enum class TransmitWatermark
 	{
@@ -181,8 +198,7 @@ struct OpenTitanUart
 	/// Clears the contents of the receive and transmit FIFOs.
 	void fifos_clear() volatile
 	{
-		fifoCtrl = (fifoCtrl & ~0b11) | FifoControlTransmitReset |
-		           FifoControlReceiveReset;
+		fifoCtrl = fifoCtrl | FifoControlTransmitReset | FifoControlReceiveReset;
 	}
 
 	/**
@@ -204,7 +220,7 @@ struct OpenTitanUart
 	 */
 	void receive_watermark(ReceiveWatermark level) volatile
 	{
-		fifoCtrl = static_cast<uint32_t>(level) << 5 | (fifoCtrl & 0b11100011);
+		fifoCtrl = static_cast<uint32_t>(level) << 2 | (fifoCtrl & 0b11100011);
 	}
 
 	/// Enable the given interrupt.
@@ -240,12 +256,12 @@ struct OpenTitanUart
 
 	bool can_write() volatile
 	{
-		return transmit_fifo_level() < 32;
+		return !(status & StatusTransmitFull);
 	}
 
 	bool can_read() volatile
 	{
-		return receive_fifo_level() > 0;
+		return !(status & StatusReceiveEmpty);
 	}
 
 	/**


### PR DESCRIPTION
The function `receive_watermark` was programming the transmit watermark; not used within sonata-system presently.

Use the tx full and rx empty bits in the `status` register rather than `fifoStatus` levels to test whether writing/reading may proceed; this makes them robust against imminent and future changes to the FIFO sizes.