### PR TITLE
Update Sonata's GPIO driver to match newest HW

### DIFF
--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -6,7 +6,19 @@
         },
         "gpio" : {
             "start" : 0x80000000,
+            "end"   : 0x80000010
+        },
+        "gpio_rpi" : {
+            "start" : 0x80000010,
             "end"   : 0x80000020
+        },
+        "gpio_arduino" : {
+            "start" : 0x80000020,
+            "end"   : 0x80000030
+        },
+        "gpio_pmod" : {
+            "start" : 0x80000030,
+            "end"   : 0x80000040
         },
         "clint": {
             "start" : 0x80040000,

--- a/sdk/include/platform/sunburst/platform-gpio.hh
+++ b/sdk/include/platform/sunburst/platform-gpio.hh
@@ -3,12 +3,12 @@
 #include <stdint.h>
 
 /**
- * Represents the state of the Sonata's joystick.
+ * Represents the state of Sonata's joystick, where each possible input
+ * corresponds to a given bit in the General GPIO's input register.
  *
- * Note, that up to three of the bits may be asserted at any given time.
- * There may be up to two cardinal directions asserted when the joystick is
- * pushed in a diagonal and the joystick may be pressed while being pushed in a
- * given direction.
+ * Note that up to 3 of these bits may be asserted at any given time: pressing
+ * down the joystick whilst pushing it in a diagonal direction (i.e. 2 cardinal
+ * directions).
  */
 enum class SonataJoystick : uint8_t
 {
@@ -19,25 +19,177 @@ enum class SonataJoystick : uint8_t
 	Right   = 1 << 4,
 };
 
+namespace Internal
+{
+	/**
+	 * A simple driver for the Sonata's GPIO. This struct represents a single
+	 * GPIO instance, and the methods available to interact with that GPIO.
+	 *
+	 * GPIO instances can be implemented via subclass structs which optionally
+	 * override the three static mask attributes and/or add their own instance-
+	 * specific functionality. The subclass itself should be provided as a
+	 * template class parameter when declaring inheritance.
+	 *
+	 * Documentation source can be found at:
+	 * https://github.com/lowRISC/sonata-system/blob/a51f663fe042f07adc0d7a38601f6a5d8f91c6e6/doc/ip/gpio.md
+	 *
+	 * Rendered documentation is served from:
+	 * https://lowrisc.org/sonata-system/doc/ip/gpio.html
+	 */
+	template<class T>
+	struct SonataGpioBase
+	{
+		uint32_t output;
+		uint32_t input;
+		uint32_t debouncedInput;
+		uint32_t outputEnable;
+
+		/**
+		 * The mask of bits of the `output` register that contain meaningful
+		 * GPIO output.
+		 */
+		static const uint32_t OutputMask = 0xFFFF'FFFF;
+
+		/**
+		 * The mask of bits of the `input` and `debouncedInput` registers that
+		 * contain meaningful GPIO input.
+		 */
+		static const uint32_t InputMask = 0xFFFF'FFFF;
+
+		/**
+		 * The mask of bits of the `outputEnable` register that correspond to
+		 * GPIO pins which can have their output enabled or disabled.
+		 */
+		static const uint32_t OutputEnableMask = 0xFFFF'FFFF;
+
+		/**
+		 * Returns the bit corresponding to a given GPIO index. Will mask out
+		 * the bit if this is outside of the provided mask.
+		 */
+		constexpr static uint32_t gpio_bit(uint32_t index, uint32_t mask)
+		{
+			return (1 << index) & mask;
+		}
+
+		/**
+		 * Set the output bit for a given GPIO pin index to a specified value.
+		 * This will only have an effect if the corresponding bit is first set
+		 * to `0` (i.e. output) in the `output_enable` register, and if the pin
+		 * is a valid output pin.
+		 */
+		void set_output(uint32_t index, bool value) volatile
+		{
+			const uint32_t Bit = gpio_bit(index, T::OutputMask);
+			if (value)
+			{
+				output = output | Bit;
+			}
+			else
+			{
+				output = output & ~Bit;
+			}
+		}
+
+		/**
+		 * Set the output enable bit for a given GPIO pin index. If `enable` is
+		 * true, the GPIO pin is set to output. If `false`, it is instead set to
+		 * input mode.
+		 */
+		void set_output_enable(uint32_t index, bool enable) volatile
+		{
+			const uint32_t Bit = gpio_bit(index, T::OutputEnableMask);
+			if (enable)
+			{
+				outputEnable = outputEnable | Bit;
+			}
+			else
+			{
+				outputEnable = outputEnable & ~Bit;
+			}
+		}
+
+		/**
+		 * Read the input value for a given GPIO pin index. For this to be
+		 * meaningful, the corresponding pin must be configured to be an input
+		 * first (set output enable to `false` for the given index). If given an
+		 * invalid GPIO pin (outside the input mask), then this value will
+		 * always be false.
+		 */
+		bool read_input(uint32_t index) volatile
+		{
+			return (input & gpio_bit(index, T::InputMask)) > 0;
+		}
+
+		/**
+		 * Read the debounced input value for a given GPIO pin index. FOr this
+		 * to be meaningful, the corresponding pin must be configured to be an
+		 * input first (set output enable to `false` for the given index). If
+		 * given an invalid GPIO pin (outside the input mask), then this value
+		 * will always be false.
+		 */
+		bool read_debounced_input(uint32_t index) volatile
+		{
+			return (debouncedInput & gpio_bit(index, T::InputMask)) > 0;
+		}
+	};
+}; // namespace Internal
+
 /**
- * A Simple Driver for the Sonata's GPIO.
+ * A driver for Sonata's General GPIO (instance 0).
  *
- * Documentation source can be found at:
- * https://github.com/lowRISC/sonata-system/blob/1a59633d2515d4fe186a07d53e49ff95c18d9bbf/doc/ip/gpio.md
- *
- * Rendered documentation is served from:
+ * Documentation source:
  * https://lowrisc.org/sonata-system/doc/ip/gpio.html
  */
-struct SonataGPIO
+struct SonataGpioGeneral : Internal::SonataGpioBase<SonataGpioGeneral>
 {
-	uint32_t output;
-	uint32_t input;
-	uint32_t debouncedInput;
-	uint32_t debouncedThreshold;
-	uint32_t raspberryPiHeader;
-	uint32_t raspberryPiMask;
-	uint32_t arduinoShieldHeader;
-	uint32_t arduinoShieldMask;
+	/**
+	 * Sonata's General GPIO input/output are directly wired to different
+	 * components; there is no relation between the bit mappings used for
+	 * input and output. As such, unlike in other GPIO headers, there is
+	 * no use for the `outputEnable` register used to toggle the GPIO pin
+	 * between an "input" or "output".
+	 */
+	static const uint32_t OutputEnableMask = 0x0000'0000;
+
+	/**
+	 * The bit mappings of the output GPIO pins available in Sonata's General
+	 * GPIO.
+	 *
+	 * Source: https://lowrisc.github.io/sonata-system/doc/ip/gpio.html
+	 */
+	enum Outputs : uint32_t
+	{
+		LcdChipSelect              = (1 << 0),
+		LcdReset                   = (1 << 1),
+		LcdDc                      = (1 << 2),
+		LcdBacklight               = (1 << 3),
+		Leds                       = (0xFF << 4),
+		FlashChipSelect            = (1 << 12),
+		EthernetChipSelect         = (1 << 13),
+		EthernetReset              = (1 << 14),
+		RaspberryPiSpi0ChipSelect1 = (1 << 15),
+		RaspberryPiSpi0ChipSelect0 = (1 << 16),
+		RaspberryPiSpi1ChipSelect2 = (1 << 17),
+		RaspberryPiSpi1ChipSelect1 = (1 << 18),
+		RaspberryPiSpi1ChipSelect0 = (1 << 19),
+		ArduinoChipSelect          = (1 << 20),
+		MikroBusChipSelect         = (1 << 21),
+		MikroBusReset              = (1 << 22),
+	};
+
+	/**
+	 * The bit mappings of the input GPIO pins available in Sonata's General
+	 * GPIO.
+	 *
+	 * Source: https://lowrisc.github.io/sonata-system/doc/ip/gpio.html
+	 */
+	enum Inputs : uint32_t
+	{
+		Joystick               = (0x1F << 0),
+		DipSwitches            = (0xFF << 5),
+		MikroBusInterrupt      = (1 << 13),
+		SoftwareSelectSwitches = (0x7 << 14),
+	};
 
 	/**
 	 * The bit index of the first GPIO pin connected to a user LED.
@@ -54,14 +206,14 @@ struct SonataGPIO
 	/**
 	 * The mask covering the GPIO pins used for user LEDs.
 	 */
-	static constexpr uint32_t LEDMask = ((1 << LEDCount) - 1) << FirstLED;
+	static constexpr uint32_t LEDMask = static_cast<uint32_t>(Outputs::Leds);
 
 	/**
 	 * The output bit mask for a given user LED index
 	 */
 	constexpr static uint32_t led_bit(uint32_t index)
 	{
-		return (1 << (index + FirstLED)) & LEDMask;
+		return gpio_bit(index + FirstLED, LEDMask & OutputMask);
 	}
 
 	/**
@@ -103,15 +255,15 @@ struct SonataGPIO
 	/**
 	 * The mask covering the GPIO pins used for user switches.
 	 */
-	static constexpr uint32_t SwitchMask = ((1 << SwitchCount) - 1)
-	                                       << FirstSwitch;
+	static constexpr uint32_t SwitchMask =
+	  static_cast<uint32_t>(Inputs::DipSwitches);
 
 	/**
 	 * The input bit mask for a given user switch index
 	 */
 	constexpr static uint32_t switch_bit(uint32_t index)
 	{
-		return (1 << (index + FirstSwitch)) & SwitchMask;
+		return gpio_bit(index + FirstSwitch, SwitchMask & OutputMask);
 	}
 
 	/**
@@ -127,6 +279,101 @@ struct SonataGPIO
 	 */
 	SonataJoystick read_joystick() volatile
 	{
-		return static_cast<SonataJoystick>(input & 0x1f);
+		return static_cast<SonataJoystick>(input & Inputs::Joystick);
 	}
 };
+
+/**
+ * A driver for Sonata's Raspberry Pi HAT Header GPIO.
+ *
+ * Documentation source:
+ * https://lowrisc.org/sonata-system/doc/ip/gpio.html
+ */
+struct SonataGpioRaspberryPiHat
+  : Internal::SonataGpioBase<SonataGpioRaspberryPiHat>
+{
+	/**
+	 * The mask of bits of the `output` register that contain meaningful GPIO
+	 * output.
+	 */
+	static const uint32_t OutputMask = 0x0FFF'FFFF;
+
+	/**
+	 * The mask of bits of the `input` and `debouncedInput` registers that
+	 * contain meaningful GPIO input.
+	 */
+	static const uint32_t InputMask = 0x0FFF'FFFF;
+
+	/**
+	 * The mask of bits of the `outputEnable` register that correspond to GPIO
+	 * pins which can have their output enabled or disabled.
+	 */
+	static const uint32_t OutputEnableMask = 0x0FFF'FFFF;
+};
+
+/**
+ * A driver for Sonata's Arduino Shield Header GPIO.
+ *
+ * Documentation source:
+ * https://lowrisc.org/sonata-system/doc/ip/gpio.html
+ */
+struct SonataGpioArduinoShield
+  : Internal::SonataGpioBase<SonataGpioArduinoShield>
+{
+	/**
+	 * The mask of bits of the `output` register that contain meaningful GPIO
+	 * output.
+	 */
+	static const uint32_t OutputMask = 0x0003'FFFF;
+
+	/**
+	 * The mask of bits of the `input` and `debouncedInput` registers that
+	 * contain meaningful GPIO input.
+	 */
+	static const uint32_t InputMask = 0x0003'FFFF;
+
+	/**
+	 * The mask of bits of the `outputEnable` register that correspond to GPIO
+	 * pins which can have their output enabled or disabled.
+	 */
+	static const uint32_t OutputEnableMask = 0x0003'FFFF;
+};
+
+/**
+ * A driver for Sonata's PMOD Header GPIO.
+ *
+ * Documentation source:
+ * https://lowrisc.org/sonata-system/doc/ip/gpio.html
+ */
+struct SonataGpioPmod : Internal::SonataGpioBase<SonataGpioPmod>
+{
+	/**
+	 * The mask of bits of the `output` register that contain meaningful GPIO
+	 * output.
+	 */
+	static const uint32_t OutputMask = 0x0000'FFFF;
+
+	/**
+	 * The mask of bits of the `input` and `debouncedInput` registers that
+	 * contain meaningful GPIO input.
+	 */
+	static const uint32_t InputMask = 0x0000'FFFF;
+
+	/**
+	 * The mask of bits of the `outputEnable` register that correspond to GPIO
+	 * pins which can have their output enabled or disabled.
+	 */
+	static const uint32_t OutputEnableMask = 0x0000'FFFF;
+
+	/**
+	 * The bit mappings of the two PMOD headers available in Sonata's PMOD GPIO.
+	 */
+	enum Headers : uint32_t
+	{
+		Pmod0 = (0xFF << 0),
+		Pmod1 = (0xFF << 8),
+	};
+};
+
+// General GPIO typedef for backwards compatibility
+typedef SonataGpioGeneral SonataGPIO;


### PR DESCRIPTION
*Note: I'm making this PR to our fork for now, and this can be upstreamed later when we're sure we're happy with it, as ideally we don't want to have to update it again if there are further changes to the GPIO.*

This PR updates the GPIO (General Purpose Input Output) driver for the Sonata board to match the newest hardware specification in the [`sonata-system`](https://github.com/lowrisc/sonata-system) repo.

The relevant documentation can be found on the [Sonata System documentation](https://lowrisc.github.io/sonata-system/doc/ip/gpio.html) page, and is referenced in comments throughout the driver code.

See the commit messages and comments for a more detailed explanation. Sonata's GPIO RTL has changed so that we now have an array containing four GPIO "instances" - the general GPIO, Raspberry Pi HAT GPIO, Arduino Shield GPIO, and PMOD GPIO. Each of these expose a similar register interface (`output`, `input`, `debouncedInput` and `outputEnable`), though these have slightly different operations depending on the instance. Different instances have different bit masks that can actually be meaningfully written to (e.g. PMOD only has 16 GPIO, whereas RPi HAT has 27). General GPIO has dedicated output & input pins and thus the `outputEnable` register has no meaning, and it exposes functions to write to / read from LEDs / DIP switches.

As such, each instance is implemented by instantiating a subclass struct that overrides write/read masks and potentially implements additional methods on top. Importantly, **this PR should retain backwards compatibility with all GPIO features that were working as of 0.4.1**. This does not include the (broken at the time of 0.4.1) use of registers outside of `output` and `input`. A `typedef` is used alongside the original functions to ensure that users of Sonata should not have to make any changes to their existing code. 

Each GPIO instance is given a separate definition in the board description JSON file so that users can choose to only get capabilities for the specific GPIO that they want to use.

I've confirmed that this is working by testing with existing firmware found in the [`sonata-software`](https://github.com/lowrisc/sonata-software) repo that use GPIO, and ensured that the masks are working properly by writing a small test that uses the `set_output` methods and reading back the register afterwards. Using a multimeter to test some of the enabled GPIO outputs also shows that this seems to be working as would be expected. 