### PR TITLE
Update i2c driver for reduced FIFO depth

### DIFF
--- a/sdk/include/platform/sunburst/platform-i2c.hh
+++ b/sdk/include/platform/sunburst/platform-i2c.hh
@@ -233,6 +233,9 @@ struct OpenTitanI2c
 	  FifoControlTransmitReset = 1 << 8,
 	};
 
+	// Referred to as 'RX FIFO' in the documentation
+	static constexpr uint32_t ReceiveFifoDepth = 8;
+
 	/// Flag set when we're debugging this driver.
 	static constexpr bool DebugOpenTitanI2c = true;
 
@@ -358,7 +361,7 @@ struct OpenTitanI2c
 	                                 uint8_t        buf[],
 	                                 const uint32_t NumBytes) volatile
 	{
-		for (uint32_t idx = 0; idx < NumBytes; idx += UINT8_MAX)
+		for (uint32_t idx = 0; idx < NumBytes; idx += ReceiveFifoDepth)
 		{
 			blocking_write_byte(FormatDataStart | (Addr7 << 1) | 1u);
 			while (!format_is_empty()) {}
@@ -368,9 +371,9 @@ struct OpenTitanI2c
 				return false;
 			}
 			uint32_t bytesRemaining = NumBytes - idx;
-			bool     lastChunk      = UINT8_MAX >= bytesRemaining;
+			bool     lastChunk      = ReceiveFifoDepth >= bytesRemaining;
 			uint8_t  chunkSize =
-              lastChunk ? static_cast<uint8_t>(bytesRemaining) : UINT8_MAX;
+				lastChunk ? static_cast<uint8_t>(bytesRemaining) : ReceiveFifoDepth;
 
 			blocking_write_byte((lastChunk ? FormatDataStop : 0) |
 			                    FormatDataReadBytes | chunkSize);


### PR DESCRIPTION
The RX and format FIFOs now have 8 entries. This also fixes an issue with the previous driver that effectively assumed a 256 entry RX FIFO where it was only 64 entries.