### PR TITLE
Stdio stderr is stdout

### DIFF
--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -88,7 +88,8 @@
         "SUNBURST_SHADOW_BASE=0x30000000",
         "SUNBURST_SHADOW_SIZE=0x800",
         "ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM=1",
-        "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1"
+        "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1",
+        "STDIO_STDERR_IS_STDOUT"
     ],
     "driver_includes" : [
         "../include/platform/sunburst",

--- a/sdk/include/stdio.h
+++ b/sdk/include/stdio.h
@@ -30,7 +30,7 @@ typedef volatile void FILE;
 #	define stdin MMIO_CAPABILITY(void uart)
 #endif
 
-#if DEVICE_EXISTS(uart1)
+#if DEVICE_EXISTS(uart1) && !defined(STDIO_STDERR_IS_STDOUT)
 #	define stderr MMIO_CAPABILITY(void, uart1)
 #elif defined(stdout)
 #	define stderr stdout


### PR DESCRIPTION
uart1 is never initialized CHERIoT RTOS. So when you have a small transmit buffer the RTOS test suite fails (as it's stderr test uses uart1 and it fills up the buffer and waits forever for it to send something so it can put more character into the buffer). I've opened an upstream issue for this: https://github.com/CHERIoT-Platform/cheriot-rtos/issues/317

This side steps the problem by allowing us to force stderr to the same UART as stdout. I think we'll want this setup on Sonata anyway as we'll have one fixed UART (for debug, stdout and stderr) and 2 or 3 pin muxable UARTs and it's not appropriate to push stderr over the pin muxable ones by default.

Ideally we'll upstream this change as well.
