### PR TITLE
Usb driver refactor

### DIFF
--- a/sdk/include/platform/sunburst/platform-usbdev.hh
+++ b/sdk/include/platform/sunburst/platform-usbdev.hh
@@ -9,7 +9,7 @@
  * https://github.com/lowRISC/opentitan/tree/ab878b5d3578939a04db72d4ed966a56a869b2ed/hw/ip/usbdev
  *
  * With rendered register documentation served at:
- * https://opentitan.org/book/hw/ip/uart/doc/registers.html
+ * https://opentitan.org/book/hw/ip/usbdev/doc/registers.html
  */
 class OpenTitanUsbdev
 {

--- a/sdk/include/platform/sunburst/platform-usbdev.hh
+++ b/sdk/include/platform/sunburst/platform-usbdev.hh
@@ -137,10 +137,10 @@ class OpenTitanUsbdev {
 		InterruptLinkInError = 1 << 10,
 		/// Raised when the Available OUT/Setup Buffer FIFO overflows.
 		InterruptAvBufferOverflow = 1 << 9,
-		/// Asserted whilst the Available OUT Buffer FIFO is empty.
-		InterruptAvOutBufferEmpty = 1 << 8,
 		/// Asserted whilst the receive FIFO is full.
-		InterruptRecvFifoFull = 1 << 7,
+		InterruptRecvFifoFull = 1 << 8,
+		/// Asserted whilst the Available OUT Buffer FIFO is empty.
+		InterruptAvOutBufferEmpty = 1 << 7,
 		/// Raised when the link transitions from Suspended to non-Idle.
 		InterruptLinkResume = 1 << 6,
 		/// Raised when the link has entered the suspend state (Idle for > 3ms).
@@ -155,7 +155,7 @@ class OpenTitanUsbdev {
 		InterruptDisconnected = 1 << 2,
 		/// Asserted whilst a packet has been sent but not cleared from `inSent`.
 		InterruptPacketSent = 1 << 1,
-		/// Asserted whilst the receive FIFO is full.
+		/// Asserted whilst the receive FIFO is non-empty.
 		InterruptPacketReceived = 1 << 0,
 	} OpenTitanUsbdevInterrupt;
 


### PR DESCRIPTION
This PR refactors the USB device driver to better conform to the code style / standards used in CHERIoT RTOS. It also performs some minor refactoring on some parts of the code to improve readability. See the commit messages for more detail.

This does include changes to the driver's public interface. Changes includes:
- Fix a bug: the receive FIFO full and Available OUT FIFO empty interrupts were the wrong way around. Also fixes a couple of pieces of incorrect documentation.
- The replacement of `constexpr` address/shift etc. attributes with appropriate enum classes for encapsulating information about register fields.
- The renaming of a few attributes and methods to expand abbreviations.
- For what is now the `packet_receive` function, the order of the first two parameters (endpoint ID and buffer ID) have been swapped to have an interface consistent with the `packet_send` function. 
- The loop unrolling in `usbdev_transfer` has been made clearer and more generic. 
- C-style casts have been replaced with C++ casts
- More documentation in places
- Other minor style changes

I've copied and manually used the driver and checked that it works with the existing USB Device Check (just disconnecting), and the test in `test_runner`. Because several user-facing identifiers have changed this does require a bit of refactoring of these two files (and the `sonata-devices.hh` file, and the PLIC tests) in `sonata-system`.